### PR TITLE
Add `TeamRatingSystem` and `Rating` traits

### DIFF
--- a/src/dwz.rs
+++ b/src/dwz.rs
@@ -93,8 +93,8 @@ impl Rating for DWZRating {
     fn rating(&self) -> f64 {
         self.rating
     }
-    fn uncertainty(&self) -> f64 {
-        0.0
+    fn uncertainty(&self) -> Option<f64> {
+        None
     }
     fn new(rating: Option<f64>, _uncertainty: Option<f64>) -> Self {
         Self {

--- a/src/egf.rs
+++ b/src/egf.rs
@@ -90,8 +90,8 @@ impl Rating for EGFRating {
     fn rating(&self) -> f64 {
         self.rating
     }
-    fn uncertainty(&self) -> f64 {
-        0.0
+    fn uncertainty(&self) -> Option<f64> {
+        None
     }
     fn new(rating: Option<f64>, _uncertainty: Option<f64>) -> Self {
         Self {

--- a/src/elo.rs
+++ b/src/elo.rs
@@ -79,8 +79,8 @@ impl Rating for EloRating {
     fn rating(&self) -> f64 {
         self.rating
     }
-    fn uncertainty(&self) -> f64 {
-        0.0
+    fn uncertainty(&self) -> Option<f64> {
+        None
     }
     fn new(rating: Option<f64>, _uncertainty: Option<f64>) -> Self {
         Self {

--- a/src/elo.rs
+++ b/src/elo.rs
@@ -46,7 +46,10 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{dwz::DWZRating, fifa::FifaRating, ingo::IngoRating, uscf::USCFRating, Outcomes};
+use crate::{
+    dwz::DWZRating, fifa::FifaRating, ingo::IngoRating, uscf::USCFRating, Outcomes, Rating,
+    RatingPeriodSystem, RatingSystem,
+};
 
 /// The Elo rating of a player.
 ///
@@ -69,6 +72,20 @@ impl EloRating {
 impl Default for EloRating {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Rating for EloRating {
+    fn rating(&self) -> f64 {
+        self.rating
+    }
+    fn uncertainty(&self) -> f64 {
+        0.0
+    }
+    fn new(rating: Option<f64>, _uncertainty: Option<f64>) -> Self {
+        Self {
+            rating: rating.unwrap_or(1000.0),
+        }
     }
 }
 
@@ -134,6 +151,46 @@ impl EloConfig {
 impl Default for EloConfig {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Struct to calculate ratings and expected score for [`EloRating`]
+pub struct Elo {
+    config: EloConfig,
+}
+
+impl RatingSystem for Elo {
+    type RATING = EloRating;
+    type CONFIG = EloConfig;
+
+    fn new(config: Self::CONFIG) -> Self {
+        Self { config }
+    }
+
+    fn rate(
+        &self,
+        player_one: &EloRating,
+        player_two: &EloRating,
+        outcome: &Outcomes,
+    ) -> (EloRating, EloRating) {
+        elo(player_one, player_two, outcome, &self.config)
+    }
+
+    fn expected_score(&self, player_one: &EloRating, player_two: &EloRating) -> (f64, f64) {
+        expected_score(player_one, player_two)
+    }
+}
+
+impl RatingPeriodSystem for Elo {
+    type RATING = EloRating;
+    type CONFIG = EloConfig;
+
+    fn new(config: Self::CONFIG) -> Self {
+        Self { config }
+    }
+
+    fn rate(&self, player: &EloRating, results: &[(EloRating, Outcomes)]) -> EloRating {
+        elo_rating_period(player, results, &self.config)
     }
 }
 

--- a/src/fifa.rs
+++ b/src/fifa.rs
@@ -52,7 +52,7 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{elo::EloRating, Outcomes};
+use crate::{elo::EloRating, Outcomes, Rating, RatingPeriodSystem, RatingSystem};
 
 /// The Fifa rating of a team.
 ///
@@ -75,6 +75,20 @@ impl FifaRating {
 impl Default for FifaRating {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Rating for FifaRating {
+    fn rating(&self) -> f64 {
+        self.rating
+    }
+    fn uncertainty(&self) -> f64 {
+        0.0
+    }
+    fn new(rating: Option<f64>, _uncertainty: Option<f64>) -> Self {
+        Self {
+            rating: rating.unwrap_or(1000.0),
+        }
     }
 }
 
@@ -151,6 +165,50 @@ impl FifaConfig {
 impl Default for FifaConfig {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Struct to calculate ratings and expected score for [`FifaRating`]
+pub struct Fifa {
+    config: FifaConfig,
+}
+
+impl RatingSystem for Fifa {
+    type RATING = FifaRating;
+    type CONFIG = FifaConfig;
+
+    fn new(config: Self::CONFIG) -> Self {
+        Self { config }
+    }
+
+    fn rate(
+        &self,
+        player_one: &FifaRating,
+        player_two: &FifaRating,
+        outcome: &Outcomes,
+    ) -> (FifaRating, FifaRating) {
+        fifa(player_one, player_two, outcome, &self.config)
+    }
+
+    fn expected_score(&self, player_one: &FifaRating, player_two: &FifaRating) -> (f64, f64) {
+        expected_score(player_one, player_two)
+    }
+}
+
+impl RatingPeriodSystem for Fifa {
+    type RATING = FifaRating;
+    type CONFIG = FifaConfig;
+
+    fn new(config: Self::CONFIG) -> Self {
+        Self { config }
+    }
+
+    fn rate(&self, player: &FifaRating, results: &[(FifaRating, Outcomes)]) -> FifaRating {
+        // Need to add a config to the results.
+        let new_results: Vec<(FifaRating, Outcomes, FifaConfig)> =
+            results.iter().map(|r| (r.0, r.1, self.config)).collect();
+
+        fifa_rating_period(player, &new_results[..])
     }
 }
 

--- a/src/fifa.rs
+++ b/src/fifa.rs
@@ -82,8 +82,8 @@ impl Rating for FifaRating {
     fn rating(&self) -> f64 {
         self.rating
     }
-    fn uncertainty(&self) -> f64 {
-        0.0
+    fn uncertainty(&self) -> Option<f64> {
+        None
     }
     fn new(rating: Option<f64>, _uncertainty: Option<f64>) -> Self {
         Self {

--- a/src/glicko.rs
+++ b/src/glicko.rs
@@ -93,8 +93,8 @@ impl Rating for GlickoRating {
     fn rating(&self) -> f64 {
         self.rating
     }
-    fn uncertainty(&self) -> f64 {
-        self.deviation
+    fn uncertainty(&self) -> Option<f64> {
+        Some(self.deviation)
     }
     fn new(rating: Option<f64>, uncertainty: Option<f64>) -> Self {
         Self {

--- a/src/glicko2.rs
+++ b/src/glicko2.rs
@@ -100,8 +100,8 @@ impl Rating for Glicko2Rating {
     fn rating(&self) -> f64 {
         self.rating
     }
-    fn uncertainty(&self) -> f64 {
-        self.deviation
+    fn uncertainty(&self) -> Option<f64> {
+        Some(self.deviation)
     }
     fn new(rating: Option<f64>, uncertainty: Option<f64>) -> Self {
         Self {

--- a/src/glicko2.rs
+++ b/src/glicko2.rs
@@ -55,7 +55,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    glicko::GlickoRating, glicko_boost::GlickoBoostRating, sticko::StickoRating, Outcomes,
+    glicko::GlickoRating, glicko_boost::GlickoBoostRating, sticko::StickoRating, Outcomes, Rating,
+    RatingPeriodSystem, RatingSystem,
 };
 use std::f64::consts::PI;
 
@@ -92,6 +93,22 @@ impl Glicko2Rating {
 impl Default for Glicko2Rating {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Rating for Glicko2Rating {
+    fn rating(&self) -> f64 {
+        self.rating
+    }
+    fn uncertainty(&self) -> f64 {
+        self.deviation
+    }
+    fn new(rating: Option<f64>, uncertainty: Option<f64>) -> Self {
+        Self {
+            rating: rating.unwrap_or(1500.0),
+            deviation: uncertainty.unwrap_or(350.0),
+            volatility: 0.06,
+        }
     }
 }
 
@@ -164,6 +181,46 @@ impl Glicko2Config {
 impl Default for Glicko2Config {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Struct to calculate ratings and expected score for [`Glicko2Rating`]
+pub struct Glicko2 {
+    config: Glicko2Config,
+}
+
+impl RatingSystem for Glicko2 {
+    type RATING = Glicko2Rating;
+    type CONFIG = Glicko2Config;
+
+    fn new(config: Self::CONFIG) -> Self {
+        Self { config }
+    }
+
+    fn rate(
+        &self,
+        player_one: &Glicko2Rating,
+        player_two: &Glicko2Rating,
+        outcome: &Outcomes,
+    ) -> (Glicko2Rating, Glicko2Rating) {
+        glicko2(player_one, player_two, outcome, &self.config)
+    }
+
+    fn expected_score(&self, player_one: &Glicko2Rating, player_two: &Glicko2Rating) -> (f64, f64) {
+        expected_score(player_one, player_two)
+    }
+}
+
+impl RatingPeriodSystem for Glicko2 {
+    type RATING = Glicko2Rating;
+    type CONFIG = Glicko2Config;
+
+    fn new(config: Self::CONFIG) -> Self {
+        Self { config }
+    }
+
+    fn rate(&self, player: &Glicko2Rating, results: &[(Glicko2Rating, Outcomes)]) -> Glicko2Rating {
+        glicko2_rating_period(player, results, &self.config)
     }
 }
 

--- a/src/glicko_boost.rs
+++ b/src/glicko_boost.rs
@@ -113,8 +113,8 @@ impl Rating for GlickoBoostRating {
     fn rating(&self) -> f64 {
         self.rating
     }
-    fn uncertainty(&self) -> f64 {
-        self.deviation
+    fn uncertainty(&self) -> Option<f64> {
+        Some(self.deviation)
     }
     fn new(rating: Option<f64>, uncertainty: Option<f64>) -> Self {
         Self {

--- a/src/glicko_boost.rs
+++ b/src/glicko_boost.rs
@@ -72,7 +72,10 @@ use std::f64::consts::PI;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{glicko::GlickoRating, glicko2::Glicko2Rating, sticko::StickoRating, Outcomes};
+use crate::{
+    glicko::GlickoRating, glicko2::Glicko2Rating, sticko::StickoRating, Outcomes, Rating,
+    RatingPeriodSystem, RatingSystem,
+};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -103,6 +106,21 @@ impl GlickoBoostRating {
 impl Default for GlickoBoostRating {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Rating for GlickoBoostRating {
+    fn rating(&self) -> f64 {
+        self.rating
+    }
+    fn uncertainty(&self) -> f64 {
+        self.deviation
+    }
+    fn new(rating: Option<f64>, uncertainty: Option<f64>) -> Self {
+        Self {
+            rating: rating.unwrap_or(1500.0),
+            deviation: uncertainty.unwrap_or(350.0),
+        }
     }
 }
 
@@ -199,6 +217,59 @@ impl GlickoBoostConfig {
 impl Default for GlickoBoostConfig {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Struct to calculate ratings and expected score for [`GlickoBoost`]
+pub struct GlickoBoost {
+    config: GlickoBoostConfig,
+}
+
+impl RatingSystem for GlickoBoost {
+    type RATING = GlickoBoostRating;
+    type CONFIG = GlickoBoostConfig;
+
+    fn new(config: Self::CONFIG) -> Self {
+        Self { config }
+    }
+
+    fn rate(
+        &self,
+        player_one: &GlickoBoostRating,
+        player_two: &GlickoBoostRating,
+        outcome: &Outcomes,
+    ) -> (GlickoBoostRating, GlickoBoostRating) {
+        glicko_boost(player_one, player_two, outcome, &self.config)
+    }
+
+    fn expected_score(
+        &self,
+        player_one: &GlickoBoostRating,
+        player_two: &GlickoBoostRating,
+    ) -> (f64, f64) {
+        expected_score(player_one, player_two, &self.config)
+    }
+}
+
+impl RatingPeriodSystem for GlickoBoost {
+    type RATING = GlickoBoostRating;
+    type CONFIG = GlickoBoostConfig;
+
+    fn new(config: Self::CONFIG) -> Self {
+        Self { config }
+    }
+
+    fn rate(
+        &self,
+        player: &GlickoBoostRating,
+        results: &[(GlickoBoostRating, Outcomes)],
+    ) -> GlickoBoostRating {
+        // Need to add a colour indicator to the results, we use white everytime.
+        // The advantage of playing white is set to 0 by default, anyways.
+        let new_results: Vec<(GlickoBoostRating, Outcomes, bool)> =
+            results.iter().map(|r| (r.0, r.1, true)).collect();
+
+        glicko_boost_rating_period(player, &new_results[..], &self.config)
     }
 }
 

--- a/src/ingo.rs
+++ b/src/ingo.rs
@@ -45,7 +45,7 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{elo::EloRating, Outcomes};
+use crate::{elo::EloRating, Outcomes, Rating, RatingPeriodSystem, RatingSystem};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -81,6 +81,21 @@ impl Default for IngoRating {
     }
 }
 
+impl Rating for IngoRating {
+    fn rating(&self) -> f64 {
+        self.rating
+    }
+    fn uncertainty(&self) -> f64 {
+        0.0
+    }
+    fn new(rating: Option<f64>, _uncertainty: Option<f64>) -> Self {
+        Self {
+            rating: rating.unwrap_or(230.0),
+            age: 26,
+        }
+    }
+}
+
 impl From<(f64, usize)> for IngoRating {
     fn from((r, a): (f64, usize)) -> Self {
         Self { rating: r, age: a }
@@ -100,6 +115,45 @@ impl From<EloRating> for IngoRating {
             rating: 355.0 - (e.rating / 8.0),
             ..Default::default()
         }
+    }
+}
+
+/// Struct to calculate ratings and expected score for [`IngoRating`]
+pub struct Ingo {}
+
+impl RatingSystem for Ingo {
+    type RATING = IngoRating;
+    // No need for a config here.
+    type CONFIG = ();
+
+    fn new(_config: Self::CONFIG) -> Self {
+        Self {}
+    }
+
+    fn rate(
+        &self,
+        player_one: &IngoRating,
+        player_two: &IngoRating,
+        outcome: &Outcomes,
+    ) -> (IngoRating, IngoRating) {
+        ingo(player_one, player_two, outcome)
+    }
+
+    fn expected_score(&self, player_one: &IngoRating, player_two: &IngoRating) -> (f64, f64) {
+        expected_score(player_one, player_two)
+    }
+}
+
+impl RatingPeriodSystem for Ingo {
+    type RATING = IngoRating;
+    type CONFIG = ();
+
+    fn new(_config: Self::CONFIG) -> Self {
+        Self {}
+    }
+
+    fn rate(&self, player: &IngoRating, results: &[(IngoRating, Outcomes)]) -> IngoRating {
+        ingo_rating_period(player, results)
     }
 }
 

--- a/src/ingo.rs
+++ b/src/ingo.rs
@@ -85,8 +85,8 @@ impl Rating for IngoRating {
     fn rating(&self) -> f64 {
         self.rating
     }
-    fn uncertainty(&self) -> f64 {
-        0.0
+    fn uncertainty(&self) -> Option<f64> {
+        None
     }
     fn new(rating: Option<f64>, _uncertainty: Option<f64>) -> Self {
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,8 +380,8 @@ pub trait Rating {
     /// A single value for player's skill
     fn rating(&self) -> f64;
     /// A value for the uncertainty of a players rating.
-    /// If the algorithm does not include an uncertainty value, this will return `0.0` instead.
-    fn uncertainty(&self) -> f64;
+    /// If the algorithm does not include an uncertainty value, this will return `None`.
+    fn uncertainty(&self) -> Option<f64>;
     /// Initialise a `Rating` with provided score and uncertainty, if `None` use default.
     /// If the algorithm does not include an uncertainty value it will get dismissed.
     fn new(rating: Option<f64>, uncertainty: Option<f64>) -> Self;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,7 +396,7 @@ pub trait RatingSystem {
     type RATING: Rating + Copy + std::fmt::Debug;
     /// Config type for rating system.
     type CONFIG;
-    /// Initialise rating system with provided config.
+    /// Initialise rating system with provided config. If the rating system does not require a config, leave empty brackets.
     fn new(config: Self::CONFIG) -> Self;
     /// Calculate ratings for two players based on provided ratings and outcome.
     fn rate(
@@ -418,7 +418,7 @@ pub trait RatingPeriodSystem {
     type RATING: Rating + Copy + std::fmt::Debug;
     /// Config type for rating system.
     type CONFIG;
-    /// Initialise rating system with provided config.
+    /// Initialise rating system with provided config. If the rating system does not require a config, leave empty brackets.
     fn new(config: Self::CONFIG) -> Self;
     /// Calculate ratings for two players based on provided ratings and outcome.
     fn rate(&self, player: &Self::RATING, results: &[(Self::RATING, Outcomes)]) -> Self::RATING;
@@ -434,7 +434,7 @@ pub trait TeamRatingSystem {
     type RATING: Rating + Copy + std::fmt::Debug;
     /// Config type for rating system.
     type CONFIG;
-    /// Initialise rating system with provided config.
+    /// Initialise rating system with provided config. If the rating system does not require a config, leave empty brackets.
     fn new(config: Self::CONFIG) -> Self;
     /// Calculate ratings for two teams based on provided ratings and outcome.
     fn rate(
@@ -454,15 +454,15 @@ pub trait MultiTeamRatingSystem {
     #[cfg(not(feature = "serde"))]
     /// Rating type rating system
     type RATING: Rating + Copy + std::fmt::Debug;
-    /// Config type for rating system
+    /// Config type for rating system.
     type CONFIG;
-    /// Initialise rating system with provided config.
+    /// Initialise rating system with provided config. If the rating system does not require a config, leave empty brackets.
     fn new(config: Self::CONFIG) -> Self;
     /// Calculate ratings for multiple teams based on provided ratings and outcome.
     fn rate(
         &self,
         teams_and_ranks: &[(&[Self::RATING], MultiTeamOutcome)],
-    ) -> (Vec<Self::RATING>, Vec<Self::RATING>);
+    ) -> Vec<Vec<Self::RATING>>;
     /// Calculate expected outcome of multiple teams. Returns probability of team winning from 0.0 to 1.0.
     fn expected_score(&self, teams: &[&[Self::RATING]]) -> Vec<f64>;
 }

--- a/src/sticko.rs
+++ b/src/sticko.rs
@@ -109,8 +109,8 @@ impl Rating for StickoRating {
     fn rating(&self) -> f64 {
         self.rating
     }
-    fn uncertainty(&self) -> f64 {
-        self.deviation
+    fn uncertainty(&self) -> Option<f64> {
+        Some(self.deviation)
     }
     fn new(rating: Option<f64>, uncertainty: Option<f64>) -> Self {
         Self {

--- a/src/sticko.rs
+++ b/src/sticko.rs
@@ -70,6 +70,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     glicko::GlickoRating, glicko2::Glicko2Rating, glicko_boost::GlickoBoostRating, Outcomes,
+    Rating, RatingPeriodSystem, RatingSystem,
 };
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -101,6 +102,21 @@ impl StickoRating {
 impl Default for StickoRating {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Rating for StickoRating {
+    fn rating(&self) -> f64 {
+        self.rating
+    }
+    fn uncertainty(&self) -> f64 {
+        self.deviation
+    }
+    fn new(rating: Option<f64>, uncertainty: Option<f64>) -> Self {
+        Self {
+            rating: rating.unwrap_or(1500.0),
+            deviation: uncertainty.unwrap_or(350.0),
+        }
     }
 }
 
@@ -201,6 +217,51 @@ impl StickoConfig {
 impl Default for StickoConfig {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Struct to calculate ratings and expected score for [`StickoRating`]
+pub struct Sticko {
+    config: StickoConfig,
+}
+
+impl RatingSystem for Sticko {
+    type RATING = StickoRating;
+    type CONFIG = StickoConfig;
+
+    fn new(config: Self::CONFIG) -> Self {
+        Self { config }
+    }
+
+    fn rate(
+        &self,
+        player_one: &StickoRating,
+        player_two: &StickoRating,
+        outcome: &Outcomes,
+    ) -> (StickoRating, StickoRating) {
+        sticko(player_one, player_two, outcome, &self.config)
+    }
+
+    fn expected_score(&self, player_one: &StickoRating, player_two: &StickoRating) -> (f64, f64) {
+        expected_score(player_one, player_two, &self.config)
+    }
+}
+
+impl RatingPeriodSystem for Sticko {
+    type RATING = StickoRating;
+    type CONFIG = StickoConfig;
+
+    fn new(config: Self::CONFIG) -> Self {
+        Self { config }
+    }
+
+    fn rate(&self, player: &StickoRating, results: &[(StickoRating, Outcomes)]) -> StickoRating {
+        // Need to add a colour indicator to the results, we use white everytime.
+        // The advantage of playing white is set to 0 by default, anyways.
+        let new_results: Vec<(StickoRating, Outcomes, bool)> =
+            results.iter().map(|r| (r.0, r.1, true)).collect();
+
+        sticko_rating_period(player, &new_results[..], &self.config)
     }
 }
 

--- a/src/trueskill.rs
+++ b/src/trueskill.rs
@@ -109,8 +109,8 @@ impl Rating for TrueSkillRating {
     fn rating(&self) -> f64 {
         self.rating
     }
-    fn uncertainty(&self) -> f64 {
-        self.uncertainty
+    fn uncertainty(&self) -> Option<f64> {
+        Some(self.uncertainty)
     }
     fn new(rating: Option<f64>, uncertainty: Option<f64>) -> Self {
         Self {

--- a/src/uscf.rs
+++ b/src/uscf.rs
@@ -113,8 +113,8 @@ impl Rating for USCFRating {
     fn rating(&self) -> f64 {
         self.rating
     }
-    fn uncertainty(&self) -> f64 {
-        0.0
+    fn uncertainty(&self) -> Option<f64> {
+        None
     }
     fn new(rating: Option<f64>, _uncertainty: Option<f64>) -> Self {
         Self {

--- a/src/weng_lin.rs
+++ b/src/weng_lin.rs
@@ -102,8 +102,8 @@ impl Rating for WengLinRating {
     fn rating(&self) -> f64 {
         self.rating
     }
-    fn uncertainty(&self) -> f64 {
-        self.uncertainty
+    fn uncertainty(&self) -> Option<f64> {
+        Some(self.uncertainty)
     }
     fn new(rating: Option<f64>, uncertainty: Option<f64>) -> Self {
         Self {

--- a/src/weng_lin.rs
+++ b/src/weng_lin.rs
@@ -60,7 +60,10 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{trueskill::TrueSkillRating, MultiTeamOutcome, Outcomes};
+use crate::{
+    trueskill::TrueSkillRating, MultiTeamOutcome, MultiTeamRatingSystem, Outcomes, Rating,
+    RatingPeriodSystem, RatingSystem, TeamRatingSystem,
+};
 use std::cmp::Ordering;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -92,6 +95,21 @@ impl WengLinRating {
 impl Default for WengLinRating {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Rating for WengLinRating {
+    fn rating(&self) -> f64 {
+        self.rating
+    }
+    fn uncertainty(&self) -> f64 {
+        self.uncertainty
+    }
+    fn new(rating: Option<f64>, uncertainty: Option<f64>) -> Self {
+        Self {
+            rating: rating.unwrap_or(25.0),
+            uncertainty: uncertainty.unwrap_or(25.0 / 3.0),
+        }
     }
 }
 
@@ -145,6 +163,88 @@ impl WengLinConfig {
 impl Default for WengLinConfig {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Struct to calculate ratings and expected score for [`WengLinRating`]
+pub struct WengLin {
+    config: WengLinConfig,
+}
+
+impl RatingSystem for WengLin {
+    type RATING = WengLinRating;
+    type CONFIG = WengLinConfig;
+
+    fn new(config: Self::CONFIG) -> Self {
+        Self { config }
+    }
+
+    fn rate(
+        &self,
+        player_one: &WengLinRating,
+        player_two: &WengLinRating,
+        outcome: &Outcomes,
+    ) -> (WengLinRating, WengLinRating) {
+        weng_lin(player_one, player_two, outcome, &self.config)
+    }
+
+    fn expected_score(&self, player_one: &WengLinRating, player_two: &WengLinRating) -> (f64, f64) {
+        expected_score(player_one, player_two, &self.config)
+    }
+}
+
+impl RatingPeriodSystem for WengLin {
+    type RATING = WengLinRating;
+    type CONFIG = WengLinConfig;
+
+    fn new(config: Self::CONFIG) -> Self {
+        Self { config }
+    }
+
+    fn rate(&self, player: &WengLinRating, results: &[(WengLinRating, Outcomes)]) -> WengLinRating {
+        weng_lin_rating_period(player, results, &self.config)
+    }
+}
+
+impl TeamRatingSystem for WengLin {
+    type RATING = WengLinRating;
+    type CONFIG = WengLinConfig;
+
+    fn new(config: Self::CONFIG) -> Self {
+        Self { config }
+    }
+
+    fn rate(
+        &self,
+        team_one: &[WengLinRating],
+        team_two: &[WengLinRating],
+        outcome: &Outcomes,
+    ) -> (Vec<WengLinRating>, Vec<WengLinRating>) {
+        weng_lin_two_teams(team_one, team_two, outcome, &self.config)
+    }
+
+    fn expected_score(&self, team_one: &[Self::RATING], team_two: &[Self::RATING]) -> (f64, f64) {
+        expected_score_two_teams(team_one, team_two, &self.config)
+    }
+}
+
+impl MultiTeamRatingSystem for WengLin {
+    type RATING = WengLinRating;
+    type CONFIG = WengLinConfig;
+
+    fn new(config: Self::CONFIG) -> Self {
+        Self { config }
+    }
+
+    fn rate(
+        &self,
+        teams_and_ranks: &[(&[Self::RATING], MultiTeamOutcome)],
+    ) -> Vec<Vec<WengLinRating>> {
+        weng_lin_multi_team(teams_and_ranks, &self.config)
+    }
+
+    fn expected_score(&self, teams: &[&[Self::RATING]]) -> Vec<f64> {
+        expected_score_multi_team(teams, &self.config)
     }
 }
 
@@ -620,7 +720,7 @@ pub fn weng_lin_multi_team(
 /// 1.0 means a certain victory for the player, 0.0 means certain loss.
 /// Values near 0.5 mean a draw is likely to occur.
 ///
-/// Similar to [`expected_score_teams`].
+/// Similar to [`expected_score_two_teams`] and [`expected_score_multi_team`].
 ///
 /// # Examples
 /// ```


### PR DESCRIPTION
Each rating system has gone through the trouble having a similar or same interface so I thought it would be beneficial to add traits for the rating system and rating type. This way users could use the crate without having to specify the rating system and easily switch between different ones.

This PR only impls for trueskill at the moment